### PR TITLE
Implement session-based session auth flow

### DIFF
--- a/src/infrastructure/http/interceptors.ts
+++ b/src/infrastructure/http/interceptors.ts
@@ -1,17 +1,23 @@
 import type { RequestOptions } from '@/infrastructure/api/client/types'
+import { apiClient, ensureCsrf } from './ApiClient'
 
-export async function handleAuthError(response: Response, request: Request, options: RequestOptions) {
+export async function handleAuthError(
+  response: Response,
+  request: Request,
+  options: RequestOptions,
+) {
   // CSRF recover: 403 on POST/PUT/PATCH/DELETE and no X-XSRF-TOKEN sent
   const method = request.method?.toUpperCase()
-  const unsafe = method && !['GET','HEAD','OPTIONS','TRACE'].includes(method)
+  const unsafe = method && !['GET', 'HEAD', 'OPTIONS', 'TRACE'].includes(method)
 
   if (response.status === 403 && unsafe) {
     // fetch token cookie
     await ensureCsrf()
     // retry original request once
-    return (options.client ?? apiClient)
-      .request({ ...options, credentials: 'include', method: method as any })
-      .then(r => r.response)
+    const client = (options as any).client ?? apiClient
+    return client
+      .request({ ...(options as any), credentials: 'include', method: method as any })
+      .then((r: any) => r.response)
   }
   return response
 }

--- a/src/modules/auth/composables/useLogin.ts
+++ b/src/modules/auth/composables/useLogin.ts
@@ -1,6 +1,7 @@
 // src/modules/auth/composables/useLogin.ts
 import { apiClient, ensureCsrf } from '@/infrastructure/http/ApiClient'
 import { login as loginRequest } from '@/infrastructure/api'
+import type { MeResponses } from '@/infrastructure/api'
 import { useAuthStore } from '../store'
 import { ref } from 'vue'
 import type { LoginRequest } from '@/infrastructure/api'
@@ -28,15 +29,16 @@ export function useLogin() {
         credentials: 'include',
       })
 
-      const me = await apiClient.request({
+      const me = await apiClient.request<MeResponses, unknown, true, 'data'>({
         url: '/api/auth/me',
         method: 'GET',
         responseStyle: 'data',
         credentials: 'include',
+        throwOnError: true,
       })
-      auth.setUserInfo(me.data.userRole, me.data.email)
+      auth.setUserInfo(me.userRole as string, me.email as string)
 
-      const redirect = (route.query.redirect as string) || '/dashboard'
+      const redirect = (route.query.redirect as string) ?? '/dashboard'
       await router.replace(redirect)
     } catch (e) {
       error.value = extractErrorMessage(e, 'Login failed')

--- a/src/types/js-cookie.d.ts
+++ b/src/types/js-cookie.d.ts
@@ -1,0 +1,1 @@
+declare module 'js-cookie';

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -34,7 +34,6 @@ async function onSubmit() {
   try {
     await formRef.value?.validate()
     await login({ email: form.email, password: form.password })
-    await router.push('/dashboard')
   } catch {
     message.error(t('login.error'))
   }


### PR DESCRIPTION
## Summary
- handle CSRF retry in shared ApiClient interceptors and always send cookies
- add Pinia auth store with init/logout and typed user info
- implement login composable and view flow with redirect after /auth/me round-trip

## Testing
- `pnpm type-check`
- `pnpm test:unit --run`
- `pnpm test:e2e` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1179/chrome-linux/headless_shell)*
- `pnpm lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_689e35ee6470832884e908bf2edbb856